### PR TITLE
Fix lexer token and test harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ run: $(EXECUTABLE)
 test: $(EXECUTABLE)
 	@echo "Ejecutando tests..."
 	@for file in test*.rb; do \
-		if [ -f "$$file" ]; then \
-			echo "Compilando $$file..."; \
-			./$(EXECUTABLE) "$$file" "$${file%.rb}.asm"; \
-		fi \
+	if [ -f "$$file" ]; then \
+	echo "Compilando $$file..."; \
+	./$(EXECUTABLE) "$$file"; \
+	fi \
 	done
 
 # Limpiar archivos generados

--- a/lex.yy.c
+++ b/lex.yy.c
@@ -984,7 +984,7 @@ YY_RULE_SETUP
 case 37:
 YY_RULE_SETUP
 #line 67 "ruby_lexer.flex"
-{ return RBRACKET; }
+{ return RBRACE; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP

--- a/test_condicionales.rb
+++ b/test_condicionales.rb
@@ -1,0 +1,10 @@
+# Archivo de prueba para condicionales multiples
+numero = 7
+
+if numero > 10
+    puts "Mayor que diez"
+elsif numero == 10
+    puts "Igual a diez"
+else
+    puts "Menor que diez"
+end

--- a/test_strings_condicional.rb
+++ b/test_strings_condicional.rb
@@ -1,0 +1,11 @@
+# Test para strings con condicional
+nombre = "Ana"
+mensaje = "Hola, " + nombre
+
+if nombre == "Ana"
+    mensaje = mensaje + "!"
+else
+    mensaje = mensaje + ", quien eres?"
+end
+
+puts mensaje

--- a/test_strings_loop.rb
+++ b/test_strings_loop.rb
@@ -1,0 +1,10 @@
+# Test adicional de strings con bucle
+contador = 0
+resultado = ""
+
+while contador < 3
+    resultado = resultado + "a"
+    contador = contador + 1
+end
+
+puts resultado

--- a/test_while.rb
+++ b/test_while.rb
@@ -1,0 +1,11 @@
+# Archivo de prueba para bucle while
+contador = 1
+producto = 1
+
+while contador <= 5
+    producto = producto * contador
+    contador = contador + 1
+end
+
+puts producto
+


### PR DESCRIPTION
## Summary
- fix incorrect token in `lex.yy.c`
- ensure test harness uses correct CLI invocation
- add trailing newline to `test_while.rb`
- fix indentation in Makefile's test target

## Testing
- `make test` *(fails to build parser: multiple errors in ruby_parser.tab.c)*

------
https://chatgpt.com/codex/tasks/task_e_686d1fe536908322a13e39ba1ecf3bd7