### PR TITLE
Enable numeric conditions in IF and WHILE

### DIFF
--- a/AST_ruby.c
+++ b/AST_ruby.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include "AST_ruby.h"
 #include "tabla_simbolos.h"
 #include <stdio.h>

--- a/ruby_parser.y
+++ b/ruby_parser.y
@@ -563,16 +563,32 @@ I:
         printf("> [SENTENCIA] - IF\n");
         if (strcmp($2.tipo, tipos[3]) == 0) {
             $$.n = crearNodoCondicional($2.n, $4.n, NULL);
+        } else if (strcmp($2.tipo, tipos[0]) == 0) {
+            struct ast* cero = crearNodoTerminal(0);
+            struct ast* cond = crearNodoNoTerminal($2.n, cero, DIFERENTE);
+            $$.n = crearNodoCondicional(cond, $4.n, NULL);
+        } else if (strcmp($2.tipo, tipos[1]) == 0) {
+            struct ast* cero = crearNodoTerminalFloat(0.0);
+            struct ast* cond = crearNodoNoTerminal($2.n, cero, DIFERENTE);
+            $$.n = crearNodoCondicional(cond, $4.n, NULL);
         } else {
-            yyerror("Error: La condicion del IF debe ser booleana");
+            yyerror("Error: La condicion del IF debe ser booleana o numerica");
         }
     }
     | IF E NEWLINE S ELSE NEWLINE S END NEWLINE {
         printf("> [SENTENCIA] - IF-ELSE\n");
         if (strcmp($2.tipo, tipos[3]) == 0) {
             $$.n = crearNodoCondicional($2.n, $4.n, $7.n);
+        } else if (strcmp($2.tipo, tipos[0]) == 0) {
+            struct ast* cero = crearNodoTerminal(0);
+            struct ast* cond = crearNodoNoTerminal($2.n, cero, DIFERENTE);
+            $$.n = crearNodoCondicional(cond, $4.n, $7.n);
+        } else if (strcmp($2.tipo, tipos[1]) == 0) {
+            struct ast* cero = crearNodoTerminalFloat(0.0);
+            struct ast* cond = crearNodoNoTerminal($2.n, cero, DIFERENTE);
+            $$.n = crearNodoCondicional(cond, $4.n, $7.n);
         } else {
-            yyerror("Error: La condicion del IF debe ser booleana");
+            yyerror("Error: La condicion del IF debe ser booleana o numerica");
         }
     }
 ;
@@ -582,8 +598,16 @@ B:
         printf("> [SENTENCIA] - WHILE\n");
         if (strcmp($2.tipo, tipos[3]) == 0) {
             $$.n = crearNodoBucle($2.n, $4.n);
+        } else if (strcmp($2.tipo, tipos[0]) == 0) {
+            struct ast* cero = crearNodoTerminal(0);
+            struct ast* cond = crearNodoNoTerminal($2.n, cero, DIFERENTE);
+            $$.n = crearNodoBucle(cond, $4.n);
+        } else if (strcmp($2.tipo, tipos[1]) == 0) {
+            struct ast* cero = crearNodoTerminalFloat(0.0);
+            struct ast* cond = crearNodoNoTerminal($2.n, cero, DIFERENTE);
+            $$.n = crearNodoBucle(cond, $4.n);
         } else {
-            yyerror("Error: La condicion del WHILE debe ser booleana");
+            yyerror("Error: La condicion del WHILE debe ser booleana o numerica");
         }
     }
 ;

--- a/test_numeric_if.rb
+++ b/test_numeric_if.rb
@@ -1,0 +1,14 @@
+# Test condicional usando valores numericos directamente
+x = 0
+if x
+    puts "X es verdadero"
+else
+    puts "X es falso"
+end
+
+f = 2.5
+if f
+    puts "F es verdadero"
+else
+    puts "F es falso"
+end


### PR DESCRIPTION
## Summary
- allow `if` and `while` conditions to accept integers or floats
- ensure strdup is declared by enabling GNU extensions
- add numeric condition test

## Testing
- `make`
- `make test`
- `./ruby_compiler test_numeric_if.rb`

------
https://chatgpt.com/codex/tasks/task_e_686e8d6103208322947a2b83c5c1580b